### PR TITLE
Update Python version requirement in pyproject.toml from 3.13 to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "fhir-mcp-server"
 version = "0.1.0"
 description = "FHIR MCP Server"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "chardet>=5.2",
     "cryptography>=45.0",


### PR DESCRIPTION
I suggest changing the minimum version of Python from 3.13 to 3.12, as this requirement may be too strict for some external services that provide a seamless MCP server deployment solution (e.g. fastmcp.cloud) 